### PR TITLE
Rewrote methods as generic

### DIFF
--- a/src/model/Main.java
+++ b/src/model/Main.java
@@ -62,24 +62,25 @@ public class Main {
 
     }
 
-    /** Searches a list of Project names and returns those that contain a
+    /** Searches a list of file names of int type and returns those that contain a
      * prompted String.
      *
-     * @param str the String used for the search.
-     * @return list of Project names matching search term.
+     * @param query the String used for the search.
+     * @return list of file names matching search term.
      * 
      * @author Maple Gunn
+     * @author Nathan Grimsey
      */
-    public static ArrayList<String> searchProject (String str) {
-        ArrayList<String> foundProjects = new ArrayList<>();
-        ArrayList<String> recentProjectsList = userSettings.getRecentProjectsList();
-        for (int i = 0; i < recentProjectsList.size(); i++) {
-            String projectName = recentProjectsList.get(i);
-            if (projectName.toLowerCase().contains(str.toLowerCase())) {
-                foundProjects.add(projectName);
+    public static ArrayList<String> searchFiles (String query, int type) {
+        ArrayList<String> foundFiles = new ArrayList<>();
+        ArrayList<String> recentFilesList = userSettings.getRecentFilesList(type);
+        for (int i = 0; i < recentFilesList.size(); i++) {
+            String fileName = recentFilesList.get(i);
+            if (fileName.toLowerCase().contains(query.toLowerCase())) {
+                foundFiles.add(fileName);
             }
         }
-        return foundProjects;
+        return foundFiles;
     }
 }
 

--- a/src/model/UserSettings.java
+++ b/src/model/UserSettings.java
@@ -142,12 +142,9 @@ public class UserSettings implements Serializable {
      */
     public void updateMostRecent(String name, Path filePath, int type) {
         ArrayList<String> recentFilesList = getListFromType(type);
-        HashMap<String, String> recentFilesMap = getMapFromType(type);
-        if (recentFilesList.contains(name)) {
-            recentFilesList.remove(name);
-        }
+        recentFilesList.remove(name);
         recentFilesList.add(0, name);
-        recentFilesMap.put(name, filePath.toString());
+        getMapFromType(type).put(name, filePath.toString());
         DataIO.saveProgramData(Main.PROJECT_DATA_FILE_PATH);
     }
 
@@ -161,10 +158,8 @@ public class UserSettings implements Serializable {
      * @author Cody Dukes
      */
     public void removeFromRecent(String name, int type) {
-        ArrayList<String> recentFilesList = getListFromType(type);
-        HashMap<String, String> recentFilesMap = getMapFromType(type);
-        recentFilesList.remove(name);
-        recentFilesMap.remove(name);
+        getListFromType(type).remove(name);
+        getMapFromType(type).remove(name);
         DataIO.saveProgramData(Main.PROJECT_DATA_FILE_PATH);
     }
 

--- a/src/model/UserSettings.java
+++ b/src/model/UserSettings.java
@@ -16,6 +16,10 @@ import java.util.HashMap;
  */
 public class UserSettings implements Serializable {
 
+    public static final int PROJECT = 0;
+    public static final int TOOL = 1;
+    public static final int MATERIAL = 2;
+
     private Profile userProfile;
     private HashMap<String, String> recentProjectsMap;
     private ArrayList<String> recentProjectsList;
@@ -67,8 +71,61 @@ public class UserSettings implements Serializable {
         recentToolsList = new ArrayList<>();
         recentMaterialsMap = new HashMap<>();
         recentMaterialsList = new ArrayList<>();
-
         darkMode = false;
+    }
+
+    /**
+     * Gets the proper recent files list that corresponds with a given input type. 
+     * Valid types are PROJECT (0), TOOL (1), and MATERIAL (2). An invalid type will 
+     * throw an IllegalArgumentException. This is a private method, and the type int 
+     * should only ever be given by the backend, hence it throws an unhandled exception.
+     * 
+     * @param type is an int corresponding to PROJECT (0), TOOL (1), and MATERIAL (2).
+     * @return the ArrayList that corresponds to the given input type.
+     * 
+     * @author Nathan Grimsey
+     */
+    private ArrayList<String> getListFromType(int type) {
+        switch (type) {
+            case PROJECT:
+                return recentProjectsList;
+            
+            case TOOL:
+                return recentToolsList;
+            
+            case MATERIAL:
+                return recentMaterialsList;
+            
+            default:
+                throw new IllegalArgumentException("int " + type + " is not a valid selection.");
+        }
+    }
+
+    /**
+     * Gets the proper recent files map that corresponds with a given input type. 
+     * Valid types are PROJECT (0), TOOL (1), and MATERIAL (2). An invalid type will 
+     * throw an IllegalArgumentException. This is a private method, and the type int 
+     * should only ever be given by the backend, hence it throws an unhandled exception.
+     * 
+     * @param type is an int corresponding to PROJECT (0), TOOL (1), and MATERIAL (2).
+     * @return the HashMap that corresponds to the given input type.
+     * 
+     * @author Nathan Grimsey
+     */
+    private HashMap<String, String> getMapFromType(int type) {
+        switch (type) {
+            case PROJECT:
+                return recentProjectsMap;
+            
+            case TOOL:
+                return recentToolsMap;
+            
+            case MATERIAL:
+                return recentMaterialsMap;
+            
+            default:
+                throw new IllegalArgumentException("int " + type + " is not a valid selection.");
+        }
     }
 
     /**
@@ -78,42 +135,19 @@ public class UserSettings implements Serializable {
      * 
      * @param name the name of the current file to update as most recent.
      * @param filePath the Path to the file to update to most recent.
-     * @param type dictates whether to update Projects, Tools, or Materials using type indicators
-     *            0, 1, and 2 respectively.
+     * @param type is an int corresponding to PROJECT (0), TOOL (1), and MATERIAL (2).
      *
      * @author Cody Dukes
+     * @author Nathan Grimsey
      */
     public void updateMostRecent(String name, Path filePath, int type) {
-        switch (type) {
-            case 0:
-                if (recentProjectsList.contains(name)) {
-                    recentProjectsList.remove(name);
-                }
-                recentProjectsList.add(0, name);
-                recentProjectsMap.put(name, filePath.toString());
-                break;
-
-            case 1:
-                if (recentToolsList.contains(name)) {
-                    recentToolsList.remove(name);
-                }
-                recentToolsList.add(0, name);
-                recentToolsMap.put(name, filePath.toString());
-                break;
-
-            case 2:
-                if (recentMaterialsList.contains(name)) {
-                    recentMaterialsList.remove(name);
-                }
-                recentMaterialsList.add(0, name);
-                recentMaterialsMap.put(name, filePath.toString());
-                break;
-
-            default:
-                System.out.printf("\nInvalid type " + type + ", only 0, 1, and 2 permitted.", type);
-                return;
+        ArrayList<String> recentFilesList = getListFromType(type);
+        HashMap<String, String> recentFilesMap = getMapFromType(type);
+        if (recentFilesList.contains(name)) {
+            recentFilesList.remove(name);
         }
-
+        recentFilesList.add(0, name);
+        recentFilesMap.put(name, filePath.toString());
         DataIO.saveProgramData(Main.PROJECT_DATA_FILE_PATH);
     }
 
@@ -121,34 +155,16 @@ public class UserSettings implements Serializable {
      * Removes an element from the recents list.
      * 
      * @param name the name of the element to remove.
-     * @param type dictates which element to remove using type indicators
-     *            0 (projects), 1 (tools), and 2 (materials).
+     * @param type is an int corresponding to PROJECT (0), TOOL (1), and MATERIAL (2).
      *
      * @author Nathan Grimsey
      * @author Cody Dukes
      */
     public void removeFromRecent(String name, int type) {
-        switch (type) {
-            case 0:
-                recentProjectsList.remove(name);
-                recentProjectsMap.remove(name);
-                break;
-
-            case 1:
-                recentToolsList.remove(name);
-                recentToolsMap.remove(name);
-                break;
-
-            case 2:
-                recentMaterialsList.remove(name);
-                recentMaterialsMap.remove(name);
-                break;
-
-            default:
-                System.out.printf("\nInvalid type " + type + ", only 0, 1, and 2 permitted.", type);
-                return;
-        }
-
+        ArrayList<String> recentFilesList = getListFromType(type);
+        HashMap<String, String> recentFilesMap = getMapFromType(type);
+        recentFilesList.remove(name);
+        recentFilesMap.remove(name);
         DataIO.saveProgramData(Main.PROJECT_DATA_FILE_PATH);
     }
 
@@ -156,69 +172,26 @@ public class UserSettings implements Serializable {
      * getFilePathFromName returns the filePath associated with the element's name.
      * 
      * @param name the name of the project to return a filePath to.
-     * @param type dictates which kind of filePath to get using type indicators
-     *            0 (projects), 1 (tools), and 2 (materials).
+     * @param type is an int corresponding to PROJECT (0), TOOL (1), and MATERIAL (2).
      * @return filePath to the chosen element.
      *
      * @author Cody Dukes
+     * @author Nathan Grimsey
      */
     public Path getFilePathFromName(String name, int type) {
-        String path;
-        switch (type) {
-            case 0:
-                path = recentProjectsMap.get(name);
-                break;
-
-            case 1:
-                path = recentToolsMap.get(name);
-                break;
-
-            case 2:
-                path = recentMaterialsMap.get(name);
-                break;
-
-            default:
-                System.out.printf("\nInvalid type " + type + ", only 0, 1, and 2 permitted.", type);
-                return null;
-        }
-
-        if (path == null) {
-            return null;
-        }
-        return Path.of(path);
+        return Path.of(getMapFromType(type).get(name));
     }
 
     /**
-     * getRecentProjectsList returns the list of recent Projects.
+     * Gets a recent files list of the specified type.
      * 
-     * @return recentProjectsList the list of recent Projects.
-     *
-     * @author Cody Dukes
-     */
-    public ArrayList<String> getRecentProjectsList() {
-        return recentProjectsList;
-    }
-
-    /**
-     * getRecentToolsList returns the list of recent Tools.
+     * @param type is an int corresponding to PROJECT (0), TOOL (1), and MATERIAL (2).
+     * @return recent files list of the specified type.
      * 
-     * @return recentToolList the list of recent Tools.
-     *
-     * @author Cody Dukes
+     * @author Nathan Grimsey
      */
-    public ArrayList<String> getRecentToolsList() {
-        return recentToolsList;
-    }
-
-    /**
-     * getRecentMaterialsList returns the list of recent Materials.
-     * 
-     * @return recentMaterialsList the list of recent Materials.
-     *
-     * @author Cody Dukes
-     */
-    public ArrayList<String> getRecentMaterialsList() {
-        return recentMaterialsList;
+    public ArrayList<String> getRecentFilesList(int type) {
+        return getListFromType(type);
     }
 
     /**

--- a/src/model/UserSettings.java
+++ b/src/model/UserSettings.java
@@ -204,6 +204,8 @@ public class UserSettings implements Serializable {
      * Gets the darkMode boolean.
      * 
      * @return boolean of whether the user is in dark mode or not.
+     * 
+     * @author Nathan Grimsey
      */
     public boolean getDarkMode() {
         return darkMode;
@@ -213,6 +215,8 @@ public class UserSettings implements Serializable {
      * Sets the darkMode boolean.
      * 
      * @param mode the value to set the darkMode boolean to.
+     * 
+     * @author Nathan Grimsey
      */
     public void setDarkMode(boolean mode) {
         darkMode = mode;

--- a/src/view/ProjectSelectScreen.java
+++ b/src/view/ProjectSelectScreen.java
@@ -12,6 +12,7 @@ import javax.swing.filechooser.FileNameExtensionFilter;
 
 import model.DataIO;
 import model.Main;
+import model.UserSettings;
 
 /**
  * TCSS 360B
@@ -36,7 +37,7 @@ public class ProjectSelectScreen extends BaseSelectorScreen {
      */
     public ProjectSelectScreen(int width, int height) {
         super(width, height, title, newButtonName, importButtonName);
-        this.recentFiles = Main.userSettings.getRecentProjectsList();
+        this.recentFiles = Main.userSettings.getRecentFilesList(UserSettings.PROJECT);
         this.listPane.setListData(this.recentFiles.toArray(new String[this.recentFiles.size()]));
         this.searchBar.addActionListener(new ActionListener() {
             @Override
@@ -44,10 +45,10 @@ public class ProjectSelectScreen extends BaseSelectorScreen {
                 // System.out.println(searchBar.getText());
                 String searchText = searchBar.getText();
                 if (searchText.isEmpty()){
-                    recentFiles = Main.userSettings.getRecentProjectsList();
+                    recentFiles = Main.userSettings.getRecentFilesList(UserSettings.PROJECT);
                 }
                 else {
-                    recentFiles = Main.searchProject(searchText);
+                    recentFiles = Main.searchFiles(searchText, UserSettings.PROJECT);
                 }
                 listPane.setListData(recentFiles.toArray(new String[recentFiles.size()]));
             }
@@ -57,17 +58,20 @@ public class ProjectSelectScreen extends BaseSelectorScreen {
             public void valueChanged(ListSelectionEvent e) {
                 if (!e.getValueIsAdjusting()) {
                     String projectName = listPane.getSelectedValue();
-                    Path projectPath = Main.userSettings.getFilePathFromName(projectName, 0);
-                    if (projectPath != null) {
-                        try {
-                            Main.BASE_FRAME.openProject(DataIO.loadProject(projectPath));
+                    if (projectName != null) {
+                        Path projectPath = Main.userSettings.getFilePathFromName(projectName, UserSettings.PROJECT);
+                        if (projectPath != null) {
+                            try {
+                                Main.BASE_FRAME.openProject(DataIO.loadProject(projectPath));
+                            }
+                            catch (Exception error) {
+                                Main.userSettings.removeFromRecent(projectName, UserSettings.PROJECT);
+                                error.printStackTrace();
+                            }
                         }
-                        catch (Exception error) {
-                            error.printStackTrace();
+                        else {
+                            Main.userSettings.removeFromRecent(projectName, UserSettings.PROJECT);
                         }
-                    }
-                    else {
-                        Main.userSettings.removeFromRecent(projectName, 0);
                     }
                 }
             }
@@ -103,7 +107,7 @@ public class ProjectSelectScreen extends BaseSelectorScreen {
      * @author Nathan Grimsey
      */
     public void refresh() {
-        recentFiles = Main.userSettings.getRecentProjectsList();
+        recentFiles = Main.userSettings.getRecentFilesList(UserSettings.PROJECT);
         listPane.setListData(recentFiles.toArray(new String[recentFiles.size()]));
     }
 }


### PR DESCRIPTION
# UserSettings
- Added public static final ints PROJECT, TOOL, and MATERIAL to UserSettings for use as the "type" int in other methods.
- Added private methods getListFromType and getMapFromType to remove redundant switch cases.
- Updated updateMostRecent to use the new getListFromType and getMapFromType methods.
- UserSettings methods will now throw an IllegalArgumentException if the int type is not valid. Since these methods will only be used by backend, this is simply to ensure things are coded correctly, and error handling is not needed. If an error occurs, that means that the methods were called incorrectly and the CODE needs to be fixed.
- getFilePathFromName has been updated to use getListFromType
- removeProject was renamed to removeFromRecent, and now uses getListFromType and getMapFromType
- getRecentProjectsList, getRecentToolsList, and getRecentMaterialsList have been removed in favor of a generic getRecentFilesList that uses int type

# Main
- Updated searchProjects to a generic searchFiles that takes int type.

# ProjectSelectorScreen
- Updated all calls to UserSettings to use the public variable UserSettings.PROJECT, and use generic methods.